### PR TITLE
pkg, version: Capture branch name with hyphens

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,10 +2,10 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 jobs:
   test:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,25 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version:
+          - 1.16.x
+          - 1.17.x
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - run: go test ./...

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -35,6 +35,8 @@ func TestParse(t *testing.T) {
 		{input: "0.6.6-internal-rc1-0-g12345678-HEAD", want: "v0.6.6-internal-rc1"},
 		{input: "0.6.6-rc1-g12345678-master", want: "v0.0.0-unofficial"}, // unparseable: no commits present
 		{input: "", want: "v0.0.0-unofficial"},
+		{input: "0.6.6-rc1-15-g12345678-want-more-branch", want: "v0.6.6-rc1-want-more-branch (12345678, +15)"}, // branch name with hypens should be captured.
+		{input: "v0.6.6-rc1-15-g12345678-want-more-branch", want: "v0.6.6-rc1-want-more-branch (12345678, +15)"},
 	}
 	for _, test := range tests {
 		t.Run(test.input, func(t *testing.T) {


### PR DESCRIPTION
This patch allows capturing a branch name with hyphens (e.g. `this-is-a-branch`) in the parsed version.