### PR TITLE
Add test for IRQService

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,6 @@ jobs:
           - 1.17.x
         os:
           - ubuntu-latest
-          - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -23,3 +22,5 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - run: go test ./...
+        env:
+          GOMAXPROCS: 4

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/oklog/run v1.1.0
 	github.com/spf13/pflag v1.0.5
 	github.com/tetratelabs/multierror v1.1.0
-	github.com/tetratelabs/telemetry v0.1.0
+	github.com/tetratelabs/telemetry v0.7.1
 )
 
 require github.com/hashicorp/errwrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,3 +10,5 @@ github.com/tetratelabs/multierror v1.1.0 h1:cKmV/Pbf42K5wp8glxa2YIausbxIraPN8fzr
 github.com/tetratelabs/multierror v1.1.0/go.mod h1:kH3SzI/z+FwEbV9bxQDx4GiIgE2djuyb8wiB2DaUBnY=
 github.com/tetratelabs/telemetry v0.1.0 h1:iV+hg0Fue+ATWQxb1gR2D2IqRZasKZO13gch1IQo4NA=
 github.com/tetratelabs/telemetry v0.1.0/go.mod h1:0ML85UszIK/NTN/DgA8DtpWA3iPSri02KmG7CExVOdk=
+github.com/tetratelabs/telemetry v0.7.1 h1:IiDiiZgShKlHjPFgCAE6ZD4URH3r8yj7SDAEN/ImHYA=
+github.com/tetratelabs/telemetry v0.7.1/go.mod h1:jDUcf1A2u4F5V1io5RdipM/bKz/hFCsx/RAgGopC37s=

--- a/pkg/log/logging.go
+++ b/pkg/log/logging.go
@@ -26,9 +26,8 @@ import (
 // It is used by run.Group when not wired up with an explicit Logging
 // implementation.
 type Logger struct {
-	args   []interface{}
+	args []interface{}
 }
-
 
 func (l *Logger) Debug(msg string, keyValuePairs ...interface{}) {
 	args := []interface{}{
@@ -60,6 +59,20 @@ func (l *Logger) Error(msg string, err error, keyValuePairs ...interface{}) {
 func (l *Logger) With(_ ...interface{}) telemetry.Logger {
 	// not used by run.Group
 	return l
+}
+
+func (l *Logger) Clone() telemetry.Logger {
+	// not used by run.Group
+	return l
+}
+
+func (l *Logger) Level() telemetry.Level {
+	// not used by run.Group
+	return telemetry.LevelNone
+}
+
+func (l *Logger) SetLevel(telemetry.Level) {
+	// not used by run.Group
 }
 
 func (l *Logger) KeyValuesToContext(ctx context.Context, _ ...interface{}) context.Context {

--- a/pkg/test/irqhandler.go
+++ b/pkg/test/irqhandler.go
@@ -79,7 +79,7 @@ func (i *irqSvc) Close() error {
 	defer i.mu.Unlock()
 
 	if i.irq != nil {
-		i.irq <- nil
+		i.irq <- run.ErrRequestedShutdown
 	}
 	return nil
 }

--- a/pkg/test/irqhandler_test.go
+++ b/pkg/test/irqhandler_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) Tetrate, Inc 2022.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/tetratelabs/run"
+	"github.com/tetratelabs/run/pkg/test"
+	"github.com/tetratelabs/telemetry"
+)
+
+// TestIRQService test if irqs returns a valid error for deliberate termination.
+func TestIRQService(t *testing.T) {
+	var (
+		g    = &run.Group{Name: "test", Logger: telemetry.NoopLogger()}
+		irqs = test.NewIRQService(func() {})
+	)
+
+	g.Register(irqs)
+	if err := g.RunConfig(); err != nil {
+		t.Fatalf("configuring run.Group: %v", err)
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	t.Run("primary thread", func(t *testing.T) {
+		t.Parallel()
+		defer wg.Done()
+
+		if err := g.Run(); err != nil {
+			t.Fatalf("server exit: %v", err)
+		}
+	})
+
+	// Try to close the run group on primary thread from the secondary thread.
+	t.Run("secondary thread", func(t *testing.T) {
+		t.Parallel()
+		defer func() {
+			irqs.Close()
+			wg.Done()
+		}()
+	})
+
+	t.Run("waiter thread", func(t *testing.T) {
+		t.Parallel()
+		wg.Wait()
+	})
+}


### PR DESCRIPTION
The intent of this PR is, firstly, to debug why a run group instance is terminated with the following error when closed by an irq Service (by calling `Close()`):

```
    irqhandler_test.go:46: server exit: run terminated without explicit error condition
```

Seems like the IRQ Service failed to return a proper error?

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>