### PR TITLE
Adds optional ServiceContext interface as alternative to Service interface

### DIFF
--- a/pkg/log/logging.go
+++ b/pkg/log/logging.go
@@ -34,6 +34,7 @@ func (l *Logger) Debug(msg string, keyValuePairs ...interface{}) {
 		time.Now().Format("2006-01-02 15:04:05.000000  "),
 		"msg", msg, "level", "debug",
 	}
+	args = append(args, l.args...)
 	args = append(args, keyValuePairs...)
 	log.Println(args...)
 }
@@ -43,6 +44,7 @@ func (l *Logger) Info(msg string, keyValuePairs ...interface{}) {
 		time.Now().Format("2006-01-02 15:04:05.000000  "),
 		"msg", msg, "level", "info",
 	}
+	args = append(args, l.args...)
 	args = append(args, keyValuePairs...)
 	log.Println(args...)
 }
@@ -52,18 +54,21 @@ func (l *Logger) Error(msg string, err error, keyValuePairs ...interface{}) {
 		time.Now().Format("2006-01-02 15:04:05.000000  "),
 		"msg", msg, "level", "error", "error", err.Error(),
 	}
+	args = append(args, l.args...)
 	args = append(args, keyValuePairs...)
 	log.Println(args...)
 }
 
-func (l *Logger) With(_ ...interface{}) telemetry.Logger {
-	// not used by run.Group
-	return l
+func (l Logger) With(keyValuePairs ...interface{}) telemetry.Logger {
+	newLogger := l.Clone().(*Logger)
+	newLogger.args = append(newLogger.args, keyValuePairs...)
+	return newLogger
 }
 
 func (l *Logger) Clone() telemetry.Logger {
-	// not used by run.Group
-	return l
+	return &Logger{
+		args: append(([]interface{})(nil), l.args...),
+	}
 }
 
 func (l *Logger) Level() telemetry.Level {


### PR DESCRIPTION
`run.Group` currently provides the `Service` interface to allow `Unit`s to start a blocking service with `Serve()` and be informed to shutdown on `GracefulStop()`. Some projects have started to use `context.Context` for not just request cancellation but even process cancellation. Good examples can be found for instance in various Kubernetes APIs.

This PR adds the ability to have a `Unit` which starts a blocking call and get notified through the by `run.Group` provided `context.Context` that it is time to cleanup and shut down.

Here is an example of a service using this logic:

```go
func main() {
	g := run.Group{Name: "Example"}
	g.Register(
		&signal.Handler{},
		&MyService{},
	)
	if err := g.Run(); err != nil {
		fmt.Printf("ERROR: %+v\n", err)
	}
}

type MyService struct{}

func (m MyService) Name() string {
	return "MyService"
}

func (m *MyService) ServeContext(ctx context.Context) error {
	ticker := time.NewTicker(1 * time.Second)
	defer ticker.Stop()
	for {
		select {
		case <-ctx.Done():
			// we are requested to exit
			return nil
		case <-ticker.C:
			fmt.Println("process some stuff")
		}
	}
}
```