### PR TITLE
Fix race in run unit graceful stop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.17
 
 require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/oklog/run v1.1.0
 	github.com/spf13/pflag v1.0.5
 	github.com/tetratelabs/multierror v1.1.0
 	github.com/tetratelabs/telemetry v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -2,13 +2,9 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczGlG91VSDkswnjF5A8=
 github.com/logrusorgru/aurora v2.0.3+incompatible/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
-github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
-github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/tetratelabs/multierror v1.1.0 h1:cKmV/Pbf42K5wp8glxa2YIausbxIraPN8fzru9Pn1Cg=
 github.com/tetratelabs/multierror v1.1.0/go.mod h1:kH3SzI/z+FwEbV9bxQDx4GiIgE2djuyb8wiB2DaUBnY=
-github.com/tetratelabs/telemetry v0.1.0 h1:iV+hg0Fue+ATWQxb1gR2D2IqRZasKZO13gch1IQo4NA=
-github.com/tetratelabs/telemetry v0.1.0/go.mod h1:0ML85UszIK/NTN/DgA8DtpWA3iPSri02KmG7CExVOdk=
 github.com/tetratelabs/telemetry v0.7.1 h1:IiDiiZgShKlHjPFgCAE6ZD4URH3r8yj7SDAEN/ImHYA=
 github.com/tetratelabs/telemetry v0.7.1/go.mod h1:jDUcf1A2u4F5V1io5RdipM/bKz/hFCsx/RAgGopC37s=


### PR DESCRIPTION
We don't know when the Serve goroutines will start, and it could be the case that scheduling N goroutines, one already returns while the others have not yet been scheduled. In that case it is possible that the unit termination is called before the serving goroutine starts, which would cause the goroutine to start anyway and hang forever.

Instead of having individual units deal with this in their serving methods, we just avoid running them if termination has already been signaled.